### PR TITLE
Add Mixed Serialization Graph Testing

### DIFF
--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -1,3 +1,4 @@
+use crate::scheduler::msgt::error::MixedSerializationGraphError;
 use crate::scheduler::owh::error::OptimisedWaitHitError;
 use crate::scheduler::sgt::error::SerializationGraphError;
 use crate::scheduler::tpl::error::TwoPhaseLockingError;
@@ -98,6 +99,8 @@ pub enum NonFatalError {
 
     SerializationGraph(SerializationGraphError),
 
+    MixedSerializationGraph(MixedSerializationGraphError),
+
     WaitHitError(WaitHitError),
 
     OptimisedWaitHitError(OptimisedWaitHitError),
@@ -167,6 +170,7 @@ impl fmt::Display for NonFatalError {
             NonSerializable => write!(f, "non-serializable behaviour"),
             SmallBankError(ref e) => write!(f, "{}", e),
             SerializationGraph(ref e) => write!(f, "{}", e),
+            MixedSerializationGraph(ref e) => write!(f, "{}", e),
             WaitHitError(ref e) => write!(f, "{}", e),
             OptimisedWaitHitError(ref e) => write!(f, "{}", e),
             TwoPhaseLockingError(ref e) => write!(f, "{}", e),
@@ -189,6 +193,12 @@ impl error::Error for FatalError {
 impl From<SerializationGraphError> for NonFatalError {
     fn from(error: SerializationGraphError) -> Self {
         NonFatalError::SerializationGraph(error)
+    }
+}
+
+impl From<MixedSerializationGraphError> for NonFatalError {
+    fn from(error: MixedSerializationGraphError) -> Self {
+        NonFatalError::MixedSerializationGraph(error)
     }
 }
 

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -3,15 +3,10 @@ use crate::workloads::acid::paramgen::AcidTransactionProfile;
 use crate::workloads::acid::AcidTransaction;
 use crate::workloads::smallbank::paramgen::SmallBankTransactionProfile;
 use crate::workloads::smallbank::SmallBankTransaction;
-// use crate::workloads::tatp::paramgen::TatpTransactionProfile;
-// use crate::workloads::tatp::TatpTransaction;
+use crate::workloads::IsolationLevel;
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
-
-///////////////////////////////////////
-//// External messages ////
-///////////////////////////////////////
 
 /// Represents all messages types that can be sent in `spaghetti`.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -22,51 +17,32 @@ pub enum Message {
     /// Indicates ther server has succesfully closed the client's connection.
     ConnectionClosed,
 
-    /// TATP transaction request.
+    /// Transaction request.
     Request {
-        /// Client request no.
         request_no: u32,
-
-        /// Transaction type.
         transaction: Transaction,
-
-        /// Transaction parameters.
         parameters: Parameters,
+        isolation: IsolationLevel,
     },
 
     /// Response to a transaction request.
-    Response {
-        /// Client request no.
-        request_no: u32,
-
-        /// Transaction outcome.
-        outcome: Outcome,
-    },
+    Response { request_no: u32, outcome: Outcome },
 }
 
-/// Transaction types.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum Transaction {
     Acid(AcidTransaction),
-    // Tatp(TatpTransaction)
     Tatp,
     SmallBank(SmallBankTransaction),
 }
 
-/// Transaction parameters.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum Parameters {
     Acid(AcidTransactionProfile),
-    // Tatp(TatpTransactionProfile),
     Tatp,
     SmallBank(SmallBankTransactionProfile),
 }
 
-///////////////////////////////////////
-//// Internal messages /////
-///////////////////////////////////////
-
-/// Sent from the transaction manager to a write handler.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct InternalResponse {
     pub request_no: u32,
@@ -77,10 +53,7 @@ pub struct InternalResponse {
 /// Outcome of a transaction with associated value or abort reason.
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum Outcome {
-    /// Transaction committed.
     Committed { value: Option<String> },
-
-    /// Transaction aborted.
     Aborted { reason: NonFatalError },
 }
 

--- a/src/common/utils.rs
+++ b/src/common/utils.rs
@@ -177,6 +177,7 @@ pub fn execute<'a>(
         request_no,
         transaction,
         parameters,
+        isolation,
     } = txn
     {
         let res = match transaction {
@@ -232,22 +233,30 @@ pub fn execute<'a>(
                 if let Parameters::SmallBank(params) = parameters {
                     match params {
                         SmallBankTransactionProfile::Amalgamate(params) => {
-                            smallbank::procedures::amalgmate(params, scheduler, workload)
+                            smallbank::procedures::amalgmate(params, scheduler, workload, isolation)
                         }
                         SmallBankTransactionProfile::Balance(params) => {
-                            smallbank::procedures::balance(params, scheduler, workload)
+                            smallbank::procedures::balance(params, scheduler, workload, isolation)
                         }
                         SmallBankTransactionProfile::DepositChecking(params) => {
-                            smallbank::procedures::deposit_checking(params, scheduler, workload)
+                            smallbank::procedures::deposit_checking(
+                                params, scheduler, workload, isolation,
+                            )
                         }
                         SmallBankTransactionProfile::SendPayment(params) => {
-                            smallbank::procedures::send_payment(params, scheduler, workload)
+                            smallbank::procedures::send_payment(
+                                params, scheduler, workload, isolation,
+                            )
                         }
                         SmallBankTransactionProfile::TransactSaving(params) => {
-                            smallbank::procedures::transact_savings(params, scheduler, workload)
+                            smallbank::procedures::transact_savings(
+                                params, scheduler, workload, isolation,
+                            )
                         }
                         SmallBankTransactionProfile::WriteCheck(params) => {
-                            smallbank::procedures::write_check(params, scheduler, workload)
+                            smallbank::procedures::write_check(
+                                params, scheduler, workload, isolation,
+                            )
                         }
                     }
                 } else {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -9,6 +9,8 @@ use crate::scheduler::wh::WaitHit;
 use crate::storage::access::TransactionId;
 use crate::storage::datatype::Data;
 use crate::storage::Database;
+use crate::workloads::IsolationLevel;
+
 use config::Config;
 use crossbeam_epoch::Guard;
 
@@ -64,11 +66,11 @@ impl<'a> Scheduler<'a> {
         Ok(protocol)
     }
 
-    pub fn begin(&self) -> TransactionId {
+    pub fn begin(&self, isolation_level: IsolationLevel) -> TransactionId {
         use Scheduler::*;
         match self {
             SerializationGraph(sg) => sg.begin(),
-            MixedSerializationGraph(sg) => sg.begin(),
+            MixedSerializationGraph(sg) => sg.begin(isolation_level),
             WaitHit(wh) => wh.begin(),
             OptimisedWaitHit(owh) => owh.begin(),
             OptimisedWaitHitTransactionTypes(owhtt) => owhtt.begin(),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,4 +1,5 @@
 use crate::common::error::NonFatalError;
+use crate::scheduler::msgt::MixedSerializationGraph;
 use crate::scheduler::nocc::NoConcurrencyControl;
 use crate::scheduler::owh::OptimisedWaitHit;
 use crate::scheduler::owhtt::OptimisedWaitHitTransactionTypes;
@@ -19,6 +20,8 @@ pub mod owhtt;
 
 pub mod sgt;
 
+pub mod msgt;
+
 pub mod tpl;
 
 pub mod nocc;
@@ -33,6 +36,7 @@ pub enum TransactionType {
 #[derive(Debug)]
 pub enum Scheduler<'a> {
     SerializationGraph(SerializationGraph<'a>),
+    MixedSerializationGraph(MixedSerializationGraph<'a>),
     WaitHit(WaitHit),
     OptimisedWaitHit(OptimisedWaitHit<'a>),
     OptimisedWaitHitTransactionTypes(OptimisedWaitHitTransactionTypes<'a>),
@@ -46,6 +50,7 @@ impl<'a> Scheduler<'a> {
 
         let protocol = match config.get_str("protocol")?.as_str() {
             "sgt" => Scheduler::SerializationGraph(SerializationGraph::new(cores)),
+            "msgt" => Scheduler::MixedSerializationGraph(MixedSerializationGraph::new(cores)),
             "wh" => Scheduler::WaitHit(WaitHit::new(cores)),
             "owh" => Scheduler::OptimisedWaitHit(OptimisedWaitHit::new(cores)),
             "owhtt" => Scheduler::OptimisedWaitHitTransactionTypes(
@@ -63,6 +68,7 @@ impl<'a> Scheduler<'a> {
         use Scheduler::*;
         match self {
             SerializationGraph(sg) => sg.begin(),
+            MixedSerializationGraph(sg) => sg.begin(),
             WaitHit(wh) => wh.begin(),
             OptimisedWaitHit(owh) => owh.begin(),
             OptimisedWaitHitTransactionTypes(owhtt) => owhtt.begin(),
@@ -83,6 +89,9 @@ impl<'a> Scheduler<'a> {
         use Scheduler::*;
         match self {
             SerializationGraph(sg) => {
+                sg.read_value(table_id, column_id, offset, meta, database, guard)
+            }
+            MixedSerializationGraph(sg) => {
                 sg.read_value(table_id, column_id, offset, meta, database, guard)
             }
             WaitHit(wh) => wh.read_value(table_id, column_id, offset, meta, database, guard),
@@ -114,6 +123,9 @@ impl<'a> Scheduler<'a> {
             SerializationGraph(sg) => {
                 sg.write_value(value, table_id, column_id, offset, meta, database, guard)
             }
+            MixedSerializationGraph(sg) => {
+                sg.write_value(value, table_id, column_id, offset, meta, database, guard)
+            }
             WaitHit(wh) => {
                 wh.write_value(value, table_id, column_id, offset, meta, database, guard)
             }
@@ -142,6 +154,7 @@ impl<'a> Scheduler<'a> {
         use Scheduler::*;
         match self {
             SerializationGraph(sg) => sg.commit(database, guard),
+            MixedSerializationGraph(sg) => sg.commit(database, guard),
             WaitHit(wh) => wh.commit(meta, database, guard),
             OptimisedWaitHit(owh) => owh.commit(database, guard),
             OptimisedWaitHitTransactionTypes(owhtt) => {
@@ -161,6 +174,7 @@ impl<'a> Scheduler<'a> {
         use Scheduler::*;
         match self {
             SerializationGraph(sg) => sg.abort(database, guard),
+            MixedSerializationGraph(sg) => sg.abort(database, guard),
             WaitHit(wh) => wh.abort(meta, database, guard),
             OptimisedWaitHit(owh) => owh.abort(database, guard),
             OptimisedWaitHitTransactionTypes(owhtt) => owhtt.abort(database, guard),

--- a/src/scheduler/msgt.rs
+++ b/src/scheduler/msgt.rs
@@ -1,0 +1,962 @@
+use crate::common::error::NonFatalError;
+use crate::common::transaction_information::{Operation, OperationType, TransactionInformation};
+use crate::scheduler::msgt::error::MixedSerializationGraphError;
+use crate::scheduler::msgt::node::EdgeSet;
+use crate::scheduler::msgt::node::{Edge, RwNode};
+use crate::storage::access::{Access, TransactionId};
+use crate::storage::datatype::Data;
+use crate::storage::Database;
+
+use crossbeam_epoch::Guard;
+use parking_lot::Mutex;
+use rustc_hash::FxHashSet;
+use std::cell::RefCell;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use thread_local::ThreadLocal;
+use tracing::{debug, info};
+
+pub mod node;
+
+pub mod error;
+
+#[derive(Debug)]
+pub struct MixedSerializationGraph<'a> {
+    txn_ctr: ThreadLocal<RefCell<usize>>,
+    this_node: ThreadLocal<RefCell<Option<&'a RwNode>>>,
+    recycled: ThreadLocal<RefCell<Vec<EdgeSet>>>,
+    visited: ThreadLocal<RefCell<FxHashSet<usize>>>,
+    stack: ThreadLocal<RefCell<Vec<Edge>>>,
+    txn_info: ThreadLocal<RefCell<Option<TransactionInformation>>>,
+}
+
+impl<'a> MixedSerializationGraph<'a> {
+    pub fn new(size: usize) -> Self {
+        info!("Initialise serialization graph with {} thread(s)", size);
+
+        Self {
+            txn_ctr: ThreadLocal::new(),
+            this_node: ThreadLocal::new(),
+            recycled: ThreadLocal::new(),
+            visited: ThreadLocal::new(),
+            stack: ThreadLocal::new(),
+            txn_info: ThreadLocal::new(),
+        }
+    }
+
+    pub fn get_transaction(&self) -> &'a RwNode {
+        self.this_node
+            .get()
+            .unwrap()
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .clone()
+    }
+
+    pub fn get_operations(&self) -> Vec<Operation> {
+        self.txn_info
+            .get()
+            .unwrap()
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            .get()
+    }
+
+    pub fn record(
+        &self,
+        op_type: OperationType,
+        table_id: usize,
+        column_id: usize,
+        offset: usize,
+        prv: u64,
+    ) {
+        self.txn_info
+            .get()
+            .unwrap()
+            .borrow_mut()
+            .as_mut()
+            .unwrap()
+            .add(op_type, table_id, column_id, offset, prv); // record operation
+    }
+
+    pub fn begin(&self) -> TransactionId {
+        *self.txn_ctr.get_or(|| RefCell::new(0)).borrow_mut() += 1; // increment txn ctr
+        *self.txn_info.get_or(|| RefCell::new(None)).borrow_mut() =
+            Some(TransactionInformation::new()); // reset txn info
+
+        let id = self.create_node(); // create node
+
+        debug!("start {} ", id);
+
+        TransactionId::SerializationGraph(id)
+    }
+
+    pub fn create_node(&self) -> usize {
+        let thread_id: usize = std::thread::current().name().unwrap().parse().unwrap();
+        let thread_ctr = *self.txn_ctr.get().unwrap().borrow();
+
+        *self.txn_info.get_or(|| RefCell::new(None)).borrow_mut() =
+            Some(TransactionInformation::new()); // reset txn info
+
+        let mut _recycled = self.recycled.get_or(|| RefCell::new(vec![])).borrow_mut();
+
+        let incoming;
+        let outgoing;
+        // if recycled.is_empty() {
+        incoming = Mutex::new(FxHashSet::default());
+        outgoing = Mutex::new(FxHashSet::default());
+        // } else {
+        //     incoming = recycled.pop().unwrap();
+        //     outgoing = recycled.pop().unwrap();
+        // }
+
+        let node = Box::new(RwNode::new_with_sets(
+            thread_id, thread_ctr, incoming, outgoing,
+        )); // allocated node on the heap
+        let id = node::to_usize(node);
+        let nref = node::from_usize(id);
+
+        nref.set_id(id);
+
+        self.this_node
+            .get_or(|| RefCell::new(None))
+            .borrow_mut()
+            .replace(nref); // replace local node reference
+
+        id
+    }
+
+    /// Cleanup node.
+    /// When this method is called the outcome of the transaction is known.
+    ///
+    pub fn cleanup<'g>(&self, this: &'a RwNode, guard: &'g Guard) {
+        // Assert: node must be committed or aborted, but not both.
+        // assert!(
+        //     (this.is_committed() && !this.is_aborted())
+        //         || (!this.is_committed() && this.is_aborted())
+        // );
+
+        // Assumption: read/writes can still be found, thus, edges can still be detected.
+        // A node's cleaned flag acts as a barrier for edge insertion.
+        let this_wlock = this.write(); // get write lock
+        this.set_cleaned(); // set as cleaned
+        drop(this_wlock); // drop write lock
+
+        let outgoing = this.take_outgoing(); // remove edge sets
+        let incoming = this.take_incoming();
+
+        let mut g = outgoing.lock(); // lock on outgoing edge set
+
+        // --- debugging ---
+        let outgoing_clone = g.clone(); // log a copy of what outgoing edge set was
+        unsafe {
+            this.outgoing_clone
+                .get()
+                .as_mut()
+                .unwrap()
+                .replace(outgoing_clone)
+        };
+        // -------------------
+
+        let this_id = node::ref_to_usize(this); // node id
+        let outgoing_set = g.iter(); // iterator over outgoing edge set
+
+        for edge in outgoing_set {
+            match edge {
+                // (this) -[rw]-> (that)
+                Edge::ReadWrite(that_id) => {
+                    // Get read lock on outgoing node - prevents node from committing.
+                    let that = node::from_usize(*that_id);
+                    let that_rlock = that.read();
+
+                    // // Assert: outgoing node may be aborted or active, but will not be committed.
+                    // assert!(!that.is_committed());
+
+                    // If active then the node will not be cleaned and edge must be removed.
+                    // Else, the node is cleaned and must have aborted.
+                    if !that.is_cleaned() {
+                        that.remove_incoming(&Edge::ReadWrite(this_id)); // remove incoming from this node
+                                                                         // unsafe { this.removed.get().as_mut().unwrap().push(edge.clone()) };
+                    } else {
+                        // assert!(that.is_aborted());
+                        // unsafe {
+                        //     this.outgoing_cleaned
+                        //         .get()
+                        //         .as_mut()
+                        //         .unwrap()
+                        //         .push(edge.clone())
+                        // };
+                    }
+
+                    // Release read lock.
+                    drop(that_rlock);
+                }
+                // (this) -[ww]-> (that)
+                Edge::WriteWrite(that_id) => {
+                    // Get read lock on outgoing node - prevents node from committing.
+                    let that = node::from_usize(*that_id);
+
+                    // Assert: outgoing node may be aborted or active, but will not be committed.
+                    // assert!(!that.is_committed());
+
+                    // If this node aborted then the outgoing node must also abort.
+                    // Else, this node is committed.
+                    if this.is_aborted() {
+                        // unsafe { this.skipped.get().as_mut().unwrap().push(edge.clone()) };
+                        that.set_cascading_abort();
+                    } else {
+                        let that_rlock = that.read();
+                        if !that.is_cleaned() {
+                            that.remove_incoming(&Edge::WriteWrite(this_id));
+                            // unsafe { this.removed.get().as_mut().unwrap().push(edge.clone()) };
+                        } else {
+                            // unsafe {
+                            //     this.outgoing_cleaned
+                            //         .get()
+                            //         .as_mut()
+                            //         .unwrap()
+                            //         .push(edge.clone())
+                            // };
+                        }
+                        drop(that_rlock);
+                    }
+                }
+                Edge::WriteRead(that) => {
+                    let that = node::from_usize(*that);
+                    if this.is_aborted() {
+                        // unsafe { this.skipped.get().as_mut().unwrap().push(edge.clone()) };
+                        that.set_cascading_abort(); // if this node is aborted and not rw; cascade abort on that node
+                    } else {
+                        let that_rlock = that.read(); // get read lock on outgoing edge
+                        if !that.is_cleaned() {
+                            that.remove_incoming(&Edge::WriteRead(this_id));
+                            // unsafe { this.removed.get().as_mut().unwrap().push(edge.clone()) };
+                        } else {
+                            // unsafe {
+                            //     this.outgoing_cleaned
+                            //         .get()
+                            //         .as_mut()
+                            //         .unwrap()
+                            //         .push(edge.clone())
+                            // };
+                        }
+                        drop(that_rlock);
+                    }
+                }
+            }
+        }
+        g.clear();
+        drop(g);
+
+        if this.is_aborted() {
+            incoming.lock().clear();
+        }
+
+        let mut recycled = self.recycled.get_or(|| RefCell::new(vec![])).borrow_mut();
+        recycled.push(incoming);
+        // recycled.push(outgoing);
+
+        let this_ptr: *const RwNode = this;
+        let this_usize = this_ptr as usize;
+        let boxed_node = node::to_box(this_usize);
+
+        unsafe {
+            guard.defer_unchecked(move || {
+                drop(boxed_node);
+            });
+        }
+    }
+
+    /// Insert an incoming edge into (this) node from (from) node, followed by a cycle check.
+    pub fn insert_and_check(
+        &self,
+        this_ref: &'a RwNode,
+        from: Edge,
+        table_id: usize,
+        column_id: usize,
+        offset: usize,
+    ) -> bool {
+        let this_id = node::ref_to_usize(this_ref); // id of this node
+
+        match from {
+            Edge::ReadWrite(from_id) => {
+                if this_id == from_id {
+                    return true; // check for self edge
+                }
+
+                let exists = this_ref.incoming_edge_exists(&from); // check if (from) --> (this) already exists
+                loop {
+                    if exists {
+                        return true; // don't add same edge twice
+                    } else {
+                        let from_ref = node::from_usize(from_id);
+                        let from_rlock = from_ref.read(); // get shared lock on (from)
+
+                        if from_ref.is_cleaned() {
+                            drop(from_rlock);
+                            return true; // if from is cleaned then it has terminated do not insert edge
+                        }
+
+                        if from_ref.is_checked() {
+                            drop(from_rlock);
+                            continue; // if (from) checked in process of terminating so try again
+                        }
+
+                        // assert!(!from_ref.is_checked());
+                        // assert!(!from_ref.is_cleaned());
+                        // assert!(!from_ref.is_complete());
+
+                        let this_rlock = this_ref.read(); // get shared lock on (this)
+                        debug!("inserted {}-[rw]->{}", from_id, this_id);
+                        this_ref.insert_incoming(Edge::ReadWrite(from_id));
+                        unsafe {
+                            this_ref.inserted.get().as_mut().unwrap().push(format!(
+                                "{}-({},{},{})",
+                                Edge::ReadWrite(from_id),
+                                table_id,
+                                column_id,
+                                offset,
+                            ))
+                        };
+
+                        from_ref.insert_outgoing(Edge::ReadWrite(this_id));
+                        drop(from_rlock);
+                        drop(this_rlock);
+
+                        let is_cycle = self.cycle_check(this_ref); // cycle check
+
+                        return !is_cycle;
+                    }
+                }
+            }
+            Edge::WriteWrite(from_id) => {
+                if this_id == from_id {
+                    return true; // check for self edge
+                }
+
+                let exists = this_ref.incoming_edge_exists(&from); // check if (from) --> (this) already exists
+                loop {
+                    if exists {
+                        return true; // don't add same edge twice
+                    } else {
+                        let from_ref = node::from_usize(from_id);
+
+                        if from_ref.is_aborted() || from_ref.is_cascading_abort() {
+                            this_ref.set_cascading_abort();
+                            return false; // then cascadingly abort (this)
+                        }
+
+                        let from_rlock = from_ref.read(); // get shared lock on (from)
+
+                        if from_ref.is_cleaned() {
+                            drop(from_rlock);
+                            return true; // if from is cleaned then it has terminated do not insert edge
+                        }
+
+                        if from_ref.is_checked() {
+                            drop(from_rlock);
+                            continue; // if (from) checked in process of terminating so try again
+                        }
+
+                        let this_rlock = this_ref.read(); // get shared lock on (this)
+                        this_ref.insert_incoming(Edge::WriteWrite(from_id));
+                        from_ref.insert_outgoing(Edge::WriteWrite(this_id));
+                        debug!("inserted {}-[o]->{}", from_id, this_id);
+                        unsafe {
+                            this_ref.inserted.get().as_mut().unwrap().push(format!(
+                                "{}-({},{},{})",
+                                Edge::WriteWrite(from_id),
+                                table_id,
+                                column_id,
+                                offset,
+                            ))
+                        };
+
+                        drop(from_rlock);
+                        drop(this_rlock);
+
+                        let is_cycle = self.cycle_check(this_ref); // cycle check
+
+                        return !is_cycle;
+                    }
+                }
+            }
+
+            Edge::WriteRead(from_id) => {
+                if this_id == from_id {
+                    return true; // check for self edge
+                }
+
+                let exists = this_ref.incoming_edge_exists(&from); // check if (from) --> (this) already exists
+                loop {
+                    if exists {
+                        return true; // don't add same edge twice
+                    } else {
+                        let from_ref = node::from_usize(from_id);
+
+                        if from_ref.is_aborted() || from_ref.is_cascading_abort() {
+                            this_ref.set_cascading_abort();
+                            return false; // then cascadingly abort (this)
+                        }
+
+                        let from_rlock = from_ref.read(); // get shared lock on (from)
+
+                        if from_ref.is_cleaned() {
+                            drop(from_rlock);
+                            return true; // if from is cleaned then it has terminated do not insert edge
+                        }
+
+                        if from_ref.is_checked() {
+                            drop(from_rlock);
+                            continue; // if (from) checked in process of terminating so try again
+                        }
+
+                        let this_rlock = this_ref.read(); // get shared lock on (this)
+                        this_ref.insert_incoming(Edge::WriteRead(from_id));
+                        from_ref.insert_outgoing(Edge::WriteRead(this_id));
+                        debug!("inserted {}-[o]->{}", from_id, this_id);
+                        unsafe {
+                            this_ref.inserted.get().as_mut().unwrap().push(format!(
+                                "{}-({},{},{})",
+                                Edge::WriteRead(from_id),
+                                table_id,
+                                column_id,
+                                offset
+                            ))
+                        };
+
+                        drop(from_rlock);
+                        drop(this_rlock);
+
+                        let is_cycle = self.cycle_check(this_ref); // cycle check
+
+                        return !is_cycle;
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn cycle_check(&self, this: &'a RwNode) -> bool {
+        let start_id = node::ref_to_usize(this);
+        let mut visited = self
+            .visited
+            .get_or(|| RefCell::new(FxHashSet::default()))
+            .borrow_mut();
+
+        let mut stack = self.stack.get_or(|| RefCell::new(Vec::new())).borrow_mut();
+
+        visited.clear();
+        stack.clear();
+
+        let this_rlock = this.read();
+        let outgoing = this.get_outgoing(); // FxHashSet<Edge<'a>>
+        let mut out = outgoing.into_iter().collect();
+        stack.append(&mut out);
+        drop(this_rlock);
+
+        while let Some(edge) = stack.pop() {
+            let current = match edge {
+                Edge::ReadWrite(node) => node,
+                Edge::WriteWrite(node) => node,
+                Edge::WriteRead(node) => node,
+            };
+
+            if start_id == current {
+                return true; // cycle found
+            }
+
+            // let current_addr = current as *const _ as usize;
+            if visited.contains(&current) {
+                continue; // already visited
+            }
+
+            visited.insert(current);
+
+            let current = node::from_usize(current);
+            let rlock = current.read();
+            let val1 =
+                !(current.is_committed() || current.is_aborted() || current.is_cascading_abort());
+            if val1 {
+                let outgoing = current.get_outgoing();
+                let mut out = outgoing.into_iter().collect();
+                stack.append(&mut out);
+            }
+
+            drop(rlock);
+        }
+
+        false
+    }
+
+    /// Check if a transaction needs to abort.
+    pub fn needs_abort(&self, this: &'a RwNode) -> bool {
+        let aborted = this.is_aborted();
+        let cascading_abort = this.is_cascading_abort();
+        aborted || cascading_abort
+    }
+
+    pub fn read_value<'g>(
+        &self,
+        table_id: usize,
+        column_id: usize,
+        offset: usize,
+        meta: &TransactionId,
+        database: &Database,
+        guard: &'g Guard,
+    ) -> Result<Data, NonFatalError> {
+        let this = self.get_transaction();
+
+        if this.is_cascading_abort() {
+            self.abort(database, guard);
+            return Err(MixedSerializationGraphError::CascadingAbort.into());
+        }
+
+        let table = database.get_table(table_id);
+        let rw_table = table.get_rwtable(offset);
+        let prv = rw_table.push_front(Access::Read(meta.clone()), guard);
+        let lsn = table.get_lsn(offset);
+
+        // Safety: ensures exculsive access to the record.
+        unsafe { spin(prv, lsn) }; // busy wait
+
+        // On acquiring the 'lock' on the record can be clean or dirty.
+        // Dirty is ok here as we allow reads uncommitted data; SGT protects against serializability violations.
+        let snapshot = rw_table.iter(guard);
+
+        let mut cyclic = false;
+
+        for (id, access) in snapshot {
+            // only interested in accesses before this one and that are write operations.
+            if id < &prv {
+                match access {
+                    // W-R conflict
+                    Access::Write(from) => {
+                        if let TransactionId::SerializationGraph(from_id) = from {
+                            if !self.insert_and_check(
+                                this,
+                                Edge::WriteRead(*from_id),
+                                table_id,
+                                column_id,
+                                offset,
+                            ) {
+                                cyclic = true;
+                                break;
+                            }
+                        }
+                    }
+                    Access::Read(_) => {}
+                }
+            }
+        }
+
+        if cyclic {
+            rw_table.erase(prv, guard); // remove from rw table
+            lsn.store(prv + 1, Ordering::Release); // update lsn
+            self.abort(database, guard); // abort
+            return Err(MixedSerializationGraphError::CycleFound.into());
+        }
+
+        let vals = table
+            .get_tuple(column_id, offset)
+            .get()
+            .get_value()
+            .unwrap()
+            .get_value(); // read
+
+        lsn.store(prv + 1, Ordering::Release); // update lsn
+
+        self.record(OperationType::Read, table_id, column_id, offset, prv); // record operation
+
+        Ok(vals)
+    }
+
+    /// Write operation.
+    ///
+    /// A write can executed iff there are no uncommitted writes on a record, else the operation is delayed.
+    pub fn write_value<'g>(
+        &self,
+        value: &Data,
+        table_id: usize,
+        column_id: usize,
+        offset: usize,
+        meta: &TransactionId,
+        database: &Database,
+        guard: &'g Guard,
+    ) -> Result<(), NonFatalError> {
+        let this = self.get_transaction();
+        let table = database.get_table(table_id);
+        let rw_table = table.get_rwtable(offset);
+        let lsn = table.get_lsn(offset);
+        let mut prv;
+        // let mut attempts = 0;
+        // let mut prvs = Vec::new();
+        // let mut delays = Vec::new();
+        // let mut cs = Vec::new();
+        // let mut seen = Vec::new();
+        // let mut brw_table;
+
+        loop {
+            // check for cascading abort
+            if self.needs_abort(this) {
+                self.abort(database, guard);
+                return Err(MixedSerializationGraphError::CascadingAbort.into());
+            }
+
+            prv = rw_table.push_front(Access::Write(meta.clone()), guard); // get ticket
+
+            //     prvs.push(prv);
+
+            // Safety: ensures exculsive access to the record.
+            unsafe { spin(prv, lsn) }; // busy wait
+                                       //  brw_table = format!("{}", rw_table);
+
+            // On acquiring the 'lock' on the record it is possible another transaction has an uncommitted write on this record.
+            // In this case the operation is restarted after a cycle check.
+            let snapshot = rw_table.iter(guard);
+
+            let mut wait = false; // flag indicating if there is an uncommitted write
+            let mut cyclic = false; // flag indicating if a cycle has been found
+
+            //     let mut conflicts = Vec::new();
+            //      let mut saw = Vec::new();
+            //     saw.push(format!("attempt: {}", attempts));
+            for (id, access) in snapshot {
+                //       saw.push(format!("{}-{}", id, access));
+                // only interested in accesses before this one and that are write operations.
+                if id < &prv {
+                    match access {
+                        // W-W conflict
+                        Access::Write(from) => {
+                            //                conflicts.push(format!("{}-{}", attempts, from));
+                            if let TransactionId::SerializationGraph(from_addr) = from {
+                                let from = node::from_usize(*from_addr); // convert to ptr
+
+                                // check if write access is uncommitted
+                                // if !from.is_committed() {
+                                if !from.is_complete() {
+                                    // if not in cycle then wait
+                                    if !self.insert_and_check(
+                                        this,
+                                        Edge::WriteWrite(*from_addr),
+                                        table_id,
+                                        column_id,
+                                        offset,
+                                    ) {
+                                        cyclic = true;
+
+                                        //         cs.push(conflicts);
+
+                                        break; // no reason to check other accesses
+                                    }
+
+                                    wait = true; // retry operation
+                                                 //      cs.push(conflicts);
+
+                                    break;
+                                } else {
+                                }
+                            }
+                        }
+                        Access::Read(_) => {}
+                    }
+                }
+            }
+            //    seen.push(saw);
+
+            // (i) transaction is in a cycle (cycle = T)
+            // abort transaction
+            if cyclic {
+                rw_table.erase(prv, guard); // remove from rw table
+                self.abort(database, guard);
+                lsn.store(prv + 1, Ordering::Release); // update lsn
+                return Err(MixedSerializationGraphError::CycleFound.into());
+            }
+
+            // (ii) there is an uncommitted write (wait = T)
+            // restart operation
+            if wait {
+                rw_table.erase(prv, guard); // remove from rw table
+
+                lsn.store(prv + 1, Ordering::Release); // update lsn
+                                                       //     attempts += 1;
+                                                       //   delays.push(wait);
+                continue;
+            }
+
+            // (iii) no w-w conflicts -> clean record (both F)
+            // check for cascading abort
+            if self.needs_abort(this) {
+                rw_table.erase(prv, guard); // remove from rw table
+                self.abort(database, guard);
+                lsn.store(prv + 1, Ordering::Release); // update lsn
+                return Err(MixedSerializationGraphError::CascadingAbort.into());
+            }
+
+            //     attempts += 1;
+            //   delays.push(wait);
+            break;
+        }
+
+        // let tuple = table.get_tuple(column_id, offset); // handle to tuple
+        // let dirty = tuple.get().is_dirty();
+        // assert: there must be not an uncommitted write, the record must be clean.
+        // assert_eq!(
+        //     dirty, false,
+        //     "\ntuple: ({},{},{}) \nstate: {:?} \nwriting node :{} \nattempts made: {} \nrwtable: {} \nprvs: {:?} \ndelays: {:?} \nconflicts: {:?} \ntuple_state: {}",
+        //     table_id,column_id,offset,  this, attempts, rw_table, prvs, delays, cs, tuple
+        // );
+
+        // assert_eq!(
+        //     dirty, false,
+        //     "\ntuple: ({},{},{}) \nwriting node :{} \nattempts made: {} \n this prv: {}\nconflicts: {:?} \nrwtable: {} \nseen: {:?} \nbeforerwtable: {}",
+        //     table_id, column_id, offset, this, attempts, prv, cs, rw_table, seen,brw_table
+        // );
+
+        // assert_eq!(
+        //     dirty, false,
+        //     "\ntuple: ({},{},{}) \nnode :{} \nattempts: {} \nrwtable: {:?}",
+        //     table_id, column_id, offset, this, attempts, rw_table
+        // );
+
+        // Now, handle R-W conflicts
+        let snapshot = rw_table.iter(guard);
+
+        let mut cyclic = false;
+
+        // only interested in accesses before this one and that are read operations.
+        for (id, access) in snapshot {
+            // check for cascading abort
+            if self.needs_abort(this) {
+                rw_table.erase(prv, guard); // remove from rw table
+
+                self.abort(database, guard);
+                lsn.store(prv + 1, Ordering::Release); // update lsn
+                return Err(MixedSerializationGraphError::CascadingAbort.into());
+            }
+
+            if id < &prv {
+                match access {
+                    Access::Read(from) => {
+                        if let TransactionId::SerializationGraph(from_addr) = from {
+                            if !self.insert_and_check(
+                                this,
+                                Edge::ReadWrite(*from_addr),
+                                table_id,
+                                column_id,
+                                offset,
+                            ) {
+                                cyclic = true;
+                                break;
+                            }
+                        }
+                    }
+                    Access::Write(_) => {}
+                }
+            }
+        }
+
+        // (iv) transaction is in a cycle (cycle = T)
+        // abort transaction
+        if cyclic {
+            rw_table.erase(prv, guard); // remove from rw table
+            self.abort(database, guard);
+            lsn.store(prv + 1, Ordering::Release); // update lsn
+            return Err(MixedSerializationGraphError::CycleFound.into());
+        }
+
+        if let Err(e) = table.get_tuple(column_id, offset).get().set_value(value) {
+            panic!("{}", e); // ASSERT: never write to an uncommitted value.
+        }
+
+        // update lsn, giving next operation access.
+        lsn.store(prv + 1, Ordering::Release);
+
+        self.record(OperationType::Write, table_id, column_id, offset, prv); // record operation
+
+        Ok(())
+    }
+
+    /// Commit operation.
+    pub fn commit<'g>(&self, database: &Database, guard: &'g Guard) -> Result<(), NonFatalError> {
+        let this = self.get_transaction();
+
+        loop {
+            if self.needs_abort(&this) {
+                self.abort(database, guard);
+                return Err(MixedSerializationGraphError::CascadingAbort.into());
+            }
+
+            let this_wlock = this.write();
+            this.set_checked(true); // prevents edge insertions
+            drop(this_wlock);
+
+            // no lock taken as only outgoing edges can be added from here
+            if this.is_incoming() {
+                this.set_checked(false); // if incoming then flip back to unchecked
+                let is_cycle = self.cycle_check(&this); // cycle check
+                if is_cycle {
+                    this.set_aborted(); // cycle so abort (this)
+                }
+                continue;
+            }
+
+            let is_cycle = self.cycle_check(&this); // final cycle check
+
+            if is_cycle {
+                this.set_aborted(); // abort
+                continue;
+            }
+
+            // no incoming edges and no cycle so commit
+            self.tidyup(database, guard, true);
+            this.set_committed();
+            self.cleanup(this, guard);
+
+            break;
+        }
+
+        this.set_complete();
+        Ok(())
+    }
+
+    /// Abort operation.
+    pub fn abort<'g>(&self, database: &Database, guard: &'g Guard) -> NonFatalError {
+        let this = self.get_transaction();
+        this.set_aborted();
+        self.cleanup(this, guard);
+        self.tidyup(database, guard, false);
+        this.set_complete();
+
+        NonFatalError::NonSerializable // TODO: return the why
+    }
+
+    /// Tidyup rwtables and tuples
+    pub fn tidyup<'g>(&self, database: &Database, guard: &'g Guard, commit: bool) {
+        let ops = self.get_operations();
+
+        for op in ops {
+            let Operation {
+                op_type,
+                table_id,
+                column_id,
+                offset,
+                prv,
+            } = op;
+
+            let table = database.get_table(table_id);
+            let rwtable = table.get_rwtable(offset);
+            let tuple = table.get_tuple(column_id, offset);
+
+            match op_type {
+                OperationType::Read => {
+                    rwtable.erase(prv, guard);
+                }
+                OperationType::Write => {
+                    if commit {
+                        tuple.get().commit();
+                    } else {
+                        tuple.get().revert();
+                    }
+                    // let dirty = tuple.get().is_dirty();
+                    // assert!(!dirty);
+                    rwtable.erase(prv, guard);
+                }
+            }
+        }
+    }
+}
+
+// Busy wait until prv matches lsn.
+unsafe fn spin(prv: u64, lsn: &AtomicU64) {
+    //  let current = lsn.load(Ordering::Relaxed);
+
+    // ASSERT: lsn values should be monotonically increasing.
+    // assert!(current <= prv);
+
+    let mut i = 0;
+    while lsn.load(Ordering::Relaxed) != prv {
+        i += 1;
+        if i >= 10000 {
+            std::thread::yield_now();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_cycle() {
+        let n1 = RwNode::new(1, 1);
+        let id1 = node::to_usize(Box::new(n1));
+        let node1 = node::from_usize(id1);
+
+        let n2 = RwNode::new(2, 1);
+        let id2 = node::to_usize(Box::new(n2));
+        let node2 = node::from_usize(id2);
+
+        node1.insert_outgoing(Edge::WriteWrite(id2));
+        node2.insert_incoming(Edge::WriteWrite(id1));
+
+        let sg = SerializationGraph::new(1);
+
+        assert_eq!(sg.cycle_check(node1), false);
+        assert_eq!(sg.cycle_check(node2), false);
+    }
+
+    #[test]
+    fn direct_cycle() {
+        let n1 = RwNode::new(1, 1);
+        let id1 = node::to_usize(Box::new(n1));
+        let node1 = node::from_usize(id1);
+
+        let n2 = RwNode::new(2, 1);
+        let id2 = node::to_usize(Box::new(n2));
+        let node2 = node::from_usize(id2);
+
+        node1.insert_outgoing(Edge::WriteWrite(id2));
+        node2.insert_incoming(Edge::WriteWrite(id1));
+
+        node1.insert_incoming(Edge::WriteWrite(id2));
+        node2.insert_outgoing(Edge::WriteWrite(id1));
+
+        let sg = SerializationGraph::new(1);
+
+        assert_eq!(sg.cycle_check(node1), true);
+        assert_eq!(sg.cycle_check(node2), true);
+    }
+
+    #[test]
+    fn trans_cycle() {
+        let n1 = RwNode::new(1, 1);
+        let id1 = node::to_usize(Box::new(n1));
+        let node1 = node::from_usize(id1);
+
+        let n2 = RwNode::new(2, 1);
+        let id2 = node::to_usize(Box::new(n2));
+        let node2 = node::from_usize(id2);
+
+        let n3 = RwNode::new(3, 1);
+        let id3 = node::to_usize(Box::new(n3));
+        let node3 = node::from_usize(id3);
+
+        node1.insert_outgoing(Edge::WriteWrite(id2));
+        node2.insert_incoming(Edge::WriteWrite(id1));
+
+        node3.insert_incoming(Edge::WriteWrite(id2));
+        node2.insert_outgoing(Edge::WriteWrite(id3));
+
+        node3.insert_outgoing(Edge::WriteWrite(id1));
+        node1.insert_incoming(Edge::WriteWrite(id3));
+
+        let sg = SerializationGraph::new(1);
+
+        assert_eq!(sg.cycle_check(node1), true);
+        assert_eq!(sg.cycle_check(node2), true);
+        assert_eq!(sg.cycle_check(node3), true);
+    }
+}

--- a/src/scheduler/msgt/error.rs
+++ b/src/scheduler/msgt/error.rs
@@ -1,0 +1,22 @@
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use std::fmt;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum MixedSerializationGraphError {
+    CycleFound,
+    CascadingAbort,
+}
+
+impl Error for MixedSerializationGraphError {}
+
+impl fmt::Display for MixedSerializationGraphError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use MixedSerializationGraphError::*;
+        let err_msg = match *self {
+            CycleFound => "cycle found",
+            CascadingAbort => "cascading abort",
+        };
+        write!(f, "{}", err_msg)
+    }
+}

--- a/src/scheduler/msgt/node.rs
+++ b/src/scheduler/msgt/node.rs
@@ -143,6 +143,10 @@ impl RwNode {
         }
     }
 
+    pub fn get_isolation_level(&self) -> IsolationLevel {
+        self.isolation_level
+    }
+
     /// Returns `true` if an edge from a given node exists in this node's edge set.
     pub fn incoming_edge_exists(&self, from: &Edge) -> bool {
         // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.

--- a/src/scheduler/msgt/node.rs
+++ b/src/scheduler/msgt/node.rs
@@ -1,0 +1,632 @@
+use parking_lot::Mutex;
+use rustc_hash::FxHashSet;
+use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use std::cell::UnsafeCell;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub fn from_usize<'a>(address: usize) -> &'a RwNode {
+    // Safety: finding an address in some access history implies the corresponding node is either:
+    // (i) pinned on another thread, so it is save to give out reference to it.
+    // (ii) scheduled for deletion by another thread, again we can safely give out a reference, as it won't be destroyed
+    // until after this thread is unpinned.
+    unsafe { &*(address as *const RwNode) }
+}
+
+pub fn to_usize(node: Box<RwNode>) -> usize {
+    let raw: *mut RwNode = Box::into_raw(node);
+    raw as usize
+}
+
+pub fn to_box(address: usize) -> Box<RwNode> {
+    // Safety: a node is owned by a single thread, so this method is only called once in order to pass the node to the
+    // epoch based garbage collector.
+    unsafe {
+        let raw = address as *mut RwNode;
+        Box::from_raw(raw)
+    }
+}
+
+pub fn ref_to_usize<'a>(node: &'a RwNode) -> usize {
+    let ptr: *const RwNode = node;
+    ptr as usize
+}
+
+pub type EdgeSet = Mutex<FxHashSet<Edge>>;
+
+/// Represents an edge to/from a node.
+/// Specifically, it captures the type of conflict, the conflicting node, and the tuple the conflict occurred on.
+#[derive(Debug, Clone, Eq, Hash, PartialEq)]
+pub enum Edge {
+    // (node id, table id, column id, offset)
+    ReadWrite(usize),
+    WriteWrite(usize),
+    WriteRead(usize),
+}
+
+/// A `RwNode` is pinned to a single thread, referred to as the 'owning' thread.
+/// This thread is responsible for creating the node and scheduling it for deletion.
+#[derive(Debug)]
+pub struct RwNode {
+    // ids
+    thread_id: usize,
+    thread_ctr: usize,
+    node_id: UnsafeCell<Option<usize>>,
+
+    incoming: UnsafeCell<Option<EdgeSet>>,
+    outgoing: UnsafeCell<Option<EdgeSet>>,
+    committed: AtomicBool,
+    cascading_abort: AtomicBool,
+    aborted: AtomicBool,
+    cleaned: AtomicBool,
+    checked: AtomicBool,
+    complete: AtomicBool,
+    lock: RwLock<u32>,
+
+    // For debugging purposes.
+    pub inserted: UnsafeCell<Vec<String>>,
+    pub removed: UnsafeCell<Vec<Edge>>,
+    pub skipped: UnsafeCell<Vec<Edge>>,
+    pub outgoing_cleaned: UnsafeCell<Vec<Edge>>,
+    pub outgoing_clone: UnsafeCell<Option<FxHashSet<Edge>>>,
+}
+
+unsafe impl<'a> Send for RwNode {}
+unsafe impl<'a> Sync for RwNode {}
+
+impl RwNode {
+    pub fn read(&self) -> RwLockReadGuard<u32> {
+        self.lock.read()
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<u32> {
+        self.lock.write()
+    }
+
+    pub fn new(thread_id: usize, thread_ctr: usize) -> Self {
+        Self {
+            thread_id,
+            thread_ctr,
+            node_id: UnsafeCell::new(None),
+
+            incoming: UnsafeCell::new(Some(Mutex::new(FxHashSet::default()))),
+            outgoing: UnsafeCell::new(Some(Mutex::new(FxHashSet::default()))),
+            inserted: UnsafeCell::new(Vec::new()),
+            committed: AtomicBool::new(false),
+            cascading_abort: AtomicBool::new(false),
+            aborted: AtomicBool::new(false),
+            cleaned: AtomicBool::new(false),
+            checked: AtomicBool::new(false),
+            complete: AtomicBool::new(false),
+            lock: RwLock::new(0),
+
+            outgoing_clone: UnsafeCell::new(None),
+            removed: UnsafeCell::new(Vec::new()),
+            skipped: UnsafeCell::new(Vec::new()),
+            outgoing_cleaned: UnsafeCell::new(Vec::new()),
+        }
+    }
+
+    pub fn new_with_sets(
+        thread_id: usize,
+        thread_ctr: usize,
+        incoming: EdgeSet,
+        outgoing: EdgeSet,
+    ) -> Self {
+        Self {
+            thread_id,
+            thread_ctr,
+            node_id: UnsafeCell::new(None),
+
+            incoming: UnsafeCell::new(Some(incoming)),
+            outgoing: UnsafeCell::new(Some(outgoing)),
+            inserted: UnsafeCell::new(Vec::new()),
+            committed: AtomicBool::new(false),
+            cascading_abort: AtomicBool::new(false),
+            aborted: AtomicBool::new(false),
+            cleaned: AtomicBool::new(false),
+            checked: AtomicBool::new(false),
+            complete: AtomicBool::new(false),
+            lock: RwLock::new(0),
+
+            outgoing_clone: UnsafeCell::new(None),
+            removed: UnsafeCell::new(Vec::new()),
+            skipped: UnsafeCell::new(Vec::new()),
+            outgoing_cleaned: UnsafeCell::new(Vec::new()),
+        }
+    }
+
+    /// Returns `true` if an edge from a given node exists in this node's edge set.
+    pub fn incoming_edge_exists(&self, from: &Edge) -> bool {
+        // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.
+        // Additonally, this method is only called by the same single thread.
+        let incoming = unsafe { self.incoming.get().as_ref() };
+
+        match incoming {
+            Some(edge_set) => match edge_set {
+                Some(edges) => {
+                    let guard = edges.lock();
+                    let exists = guard.contains(from);
+                    drop(guard);
+                    exists
+                }
+                None => panic!("incoming edge set already cleaned"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Returns `true` if the node has at least 1 incoming edge.
+    pub fn is_incoming(&self) -> bool {
+        // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.
+        // Additonally, this method is only called by the same single thread during the check_committed() operation.
+        let incoming = unsafe { self.incoming.get().as_ref() };
+
+        match incoming {
+            Some(edge_set) => match edge_set {
+                Some(edges) => {
+                    let guard = edges.lock();
+                    let res = guard.is_empty();
+                    drop(guard);
+                    !res
+                }
+                None => panic!("incoming edge set already cleaned"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Insert an incoming edge from a node.
+    pub fn insert_incoming(&self, from: Edge) {
+        // Assert: should not be attempting to insert an edge is transaction has terminated.
+        assert!(!self.is_aborted());
+        assert!(!self.is_committed());
+
+        // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.
+        let incoming = unsafe { self.incoming.get().as_ref() };
+
+        match incoming {
+            Some(edge_set) => match edge_set {
+                Some(edges) => {
+                    let mut guard = edges.lock();
+                    guard.insert(from);
+                    drop(guard);
+                }
+                None => panic!("incoming edge set already cleaned"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Remove an edge from this node's incoming edge set.
+    pub fn remove_incoming(&self, from: &Edge) {
+        // Assert: should not be attempting to insert an removed is transaction has terminated.
+        assert!(!self.is_complete());
+
+        // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.
+        let incoming = unsafe { self.incoming.get().as_ref() };
+
+        match incoming {
+            Some(edge_set) => match edge_set {
+                Some(edges) => {
+                    let mut guard = edges.lock();
+                    assert_eq!(guard.remove(from), true);
+                    drop(guard);
+                }
+                None => panic!("incoming edge set already cleaned"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Insert an outgoing edge from a node.
+    pub fn insert_outgoing(&self, to: Edge) {
+        // Safety: the incoming edge field is only mutated by a single thread during the cleanup() operation.
+        let outgoing = unsafe { self.outgoing.get().as_ref() };
+
+        match outgoing {
+            Some(edge_set) => match edge_set {
+                Some(edges) => {
+                    let mut guard = edges.lock();
+                    guard.insert(to);
+                    drop(guard);
+                }
+                None => panic!("outgoing edge set already cleaned"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Remove incoming edge set from node.
+    pub fn take_incoming(&self) -> EdgeSet {
+        let incoming = unsafe { self.incoming.get().as_mut() };
+
+        match incoming {
+            Some(edge_set) => match edge_set.take() {
+                Some(edges) => edges,
+                None => panic!("incoming edge set already removed"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Remove outgoing edge set from node.
+    pub fn take_outgoing(&self) -> EdgeSet {
+        let outgoing = unsafe { self.outgoing.get().as_mut() };
+
+        match outgoing {
+            Some(edge_set) => match edge_set.take() {
+                Some(edges) => edges,
+                None => panic!("outgoing edge set already removed"),
+            },
+            None => panic!("check unsafe"),
+        }
+    }
+
+    /// Get a clone of the outgoing edge from node.
+    pub fn get_outgoing(&self) -> FxHashSet<Edge> {
+        match unsafe { self.outgoing.get().as_ref().unwrap().as_ref() } {
+            Some(edges) => {
+                let guard = edges.lock();
+                let out = guard.clone();
+                drop(guard);
+                out
+            }
+            None => FxHashSet::default(),
+        }
+    }
+
+    /// Get a clone of the outgoing edge from node.
+    pub fn get_incoming(&self) -> FxHashSet<Edge> {
+        match unsafe { self.incoming.get().as_ref().unwrap().as_ref() } {
+            Some(edges) => {
+                let guard = edges.lock();
+                let out = guard.clone();
+                drop(guard);
+                out
+            }
+            None => FxHashSet::default(),
+        }
+    }
+
+    pub fn set_id(&self, node_id: usize) {
+        unsafe { *self.node_id.get().as_mut().unwrap() = Some(node_id) };
+    }
+
+    pub fn is_aborted(&self) -> bool {
+        self.aborted.load(Ordering::Acquire)
+    }
+
+    pub fn set_aborted(&self) {
+        self.aborted.store(true, Ordering::Release);
+    }
+
+    pub fn is_cascading_abort(&self) -> bool {
+        self.cascading_abort.load(Ordering::Acquire)
+    }
+
+    pub fn set_cascading_abort(&self) {
+        self.cascading_abort.store(true, Ordering::Release);
+    }
+
+    pub fn is_committed(&self) -> bool {
+        self.committed.load(Ordering::Acquire)
+    }
+
+    pub fn set_committed(&self) {
+        self.committed.store(true, Ordering::Release);
+    }
+
+    pub fn is_checked(&self) -> bool {
+        self.checked.load(Ordering::Acquire)
+    }
+
+    pub fn set_checked(&self, val: bool) {
+        self.checked.store(val, Ordering::Release);
+    }
+
+    pub fn is_cleaned(&self) -> bool {
+        self.cleaned.load(Ordering::Acquire)
+    }
+
+    pub fn set_cleaned(&self) {
+        self.cleaned.store(true, Ordering::Release);
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.complete.load(Ordering::Acquire)
+    }
+
+    pub fn set_complete(&self) {
+        self.complete.store(true, Ordering::Release);
+    }
+
+    pub fn print_edges(&self, incoming: bool) -> String {
+        let mut res = String::new();
+
+        let edge_set = if incoming {
+            unsafe { self.incoming.get().as_ref().unwrap().as_ref() }
+        } else {
+            unsafe { self.outgoing.get().as_ref().unwrap().as_ref() }
+        };
+
+        match edge_set {
+            // incoming edge not removed
+            Some(edges) => {
+                let guard = edges.lock(); // lock edge set
+
+                // not removed but empty
+                if guard.is_empty() {
+                    res.push_str("[ ]");
+                } else {
+                    // contains edges
+                    res.push_str(&format!("["));
+
+                    for edge in &*guard {
+                        res.push_str(&format!("{}", edge));
+                        res.push_str(", ");
+                    }
+                    res.pop(); // remove trailing ', '
+                    res.pop();
+                    res.push_str(&format!("]"));
+                }
+
+                drop(guard);
+            }
+            // edge set has been removed
+            None => res.push_str("[cleared]"),
+        };
+
+        res
+    }
+
+    pub fn depth_first_search(&self, incoming: bool) -> FxHashSet<usize> {
+        let mut visited = FxHashSet::default(); // nodes that have been visited
+        let mut stack = Vec::new(); // nodes left to visit
+
+        let edges;
+        if incoming {
+            edges = self.get_incoming(); // start nodes to visit
+        } else {
+            edges = self.get_outgoing(); // start nodes to visit
+        }
+
+        let mut inc = edges.into_iter().collect();
+        stack.append(&mut inc); // push to stack
+
+        while let Some(edge) = stack.pop() {
+            let current = match edge {
+                Edge::ReadWrite(node) => node,
+                Edge::WriteWrite(node) => node,
+                Edge::WriteRead(node) => node,
+            };
+
+            if visited.contains(&current) {
+                continue; // already visited
+            }
+
+            visited.insert(current);
+
+            let current_ref = from_usize(current);
+            let edges;
+            if incoming {
+                edges = current_ref.get_incoming(); // start nodes to visit
+            } else {
+                edges = current_ref.get_outgoing(); // start nodes to visit
+            }
+
+            let mut inc = edges.into_iter().collect();
+            stack.append(&mut inc);
+        }
+        visited
+    }
+}
+
+impl fmt::Display for Edge {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Edge::ReadWrite(id) => write!(f, "rw:{}", id).unwrap(),
+            Edge::WriteWrite(id) => write!(f, "ww:{}", id,).unwrap(),
+            Edge::WriteRead(id) => write!(f, "wr:{}", id,).unwrap(),
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for RwNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut nodes_in = self.depth_first_search(true); // nodes found from incoming edges
+                                                          //  let mut nodes_out = self.depth_first_search(false); // nodes found from incoming edges
+
+        let ptr: *const RwNode = self;
+        let id = ptr as usize;
+        nodes_in.remove(&id);
+        //     nodes_out.remove(&id);
+
+        //     let nodes: FxHashSet<_> = nodes_in.union(&nodes_out).collect();
+
+        writeln!(f).unwrap();
+        writeln!(f, "-------------------------------------------------------------------------------------------").unwrap();
+        writeln!(f, "thread id: {:?}", self.thread_id).unwrap();
+        writeln!(f, "thread ctr: {:?}", self.thread_ctr).unwrap();
+        writeln!(f, "expected ref id: {}", unsafe {
+            self.node_id.get().as_ref().unwrap().unwrap()
+        })
+        .unwrap();
+        writeln!(f, "actual ref id: {}", id).unwrap();
+        writeln!(f, "incoming: {}", self.print_edges(true)).unwrap();
+        writeln!(f, "outgoing: {}", self.print_edges(false)).unwrap();
+        writeln!(f, "inserted: {:?}", unsafe {
+            self.inserted.get().as_mut().unwrap()
+        })
+        .unwrap();
+        writeln!(f, "removed: {:?}", unsafe {
+            self.removed.get().as_mut().unwrap()
+        })
+        .unwrap();
+        writeln!(f, "skipped: {:?}", unsafe {
+            self.skipped.get().as_mut().unwrap()
+        })
+        .unwrap();
+        writeln!(f, "outgoing_cleaned: {:?}", unsafe {
+            self.outgoing_cleaned.get().as_mut().unwrap()
+        })
+        .unwrap();
+        writeln!(f, "outgoing_clone: {:?}", unsafe {
+            self.outgoing_clone.get().as_mut().unwrap()
+        })
+        .unwrap();
+
+        writeln!(
+            f,
+            "committed: {:?}, cascading: {:?}, aborted: {:?}, cleaned: {:?}, checked: {:?}, complete: {:?}",
+            self.committed, self.cascading_abort, self.aborted, self.cleaned, self.checked, self.complete
+        )
+        .unwrap();
+        writeln!(f, "-------------------------------------------------------------------------------------------").unwrap();
+        writeln!(f).unwrap();
+
+        for node in nodes_in.iter() {
+            let n = from_usize(*node);
+
+            writeln!(f, "-------------------------------------------------------------------------------------------").unwrap();
+            writeln!(f).unwrap();
+            writeln!(f, "thread id: {:?}", n.thread_id).unwrap();
+            writeln!(f, "thread ctr: {:?}", n.thread_ctr).unwrap();
+            writeln!(f, "expected ref id: {:?}", unsafe {
+                n.node_id.get().as_ref().unwrap()
+            })
+            .unwrap();
+            writeln!(f, "actual ref id: {}", node).unwrap();
+
+            writeln!(f, "incoming: {}", n.print_edges(true)).unwrap();
+            writeln!(f, "outgoing: {}", n.print_edges(false)).unwrap();
+            writeln!(f, "removed: {:?}", unsafe {
+                n.removed.get().as_mut().unwrap()
+            })
+            .unwrap();
+            writeln!(f, "skipped: {:?}", unsafe {
+                n.skipped.get().as_mut().unwrap()
+            })
+            .unwrap();
+            writeln!(f, "outgoing_cleaned: {:?}", unsafe {
+                n.outgoing_cleaned.get().as_mut().unwrap()
+            })
+            .unwrap();
+            writeln!(f, "outgoing_clone: {:?}", unsafe {
+                n.outgoing_clone.get().as_mut().unwrap()
+            })
+            .unwrap();
+            writeln!(
+                f,
+                "committed: {:?}, cascading: {:?}, aborted: {:?}, cleaned: {:?}, checked: {:?}, complete: {:?}",
+                n.committed, n.cascading_abort, n.aborted, n.cleaned, n.checked, n.complete
+            )
+            .unwrap();
+            writeln!(f, "-------------------------------------------------------------------------------------------").unwrap();
+            writeln!(f).unwrap();
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utils() {
+        let node = RwNode::new(1, 1);
+        let boxed = Box::new(node);
+        let id = to_usize(boxed);
+        let ref_node = from_usize(id);
+        let ref_id = ref_to_usize(ref_node);
+        assert_eq!(id, ref_id);
+
+        let n1 = RwNode::new(2, 1);
+        let nr1 = &n1;
+        let nr2 = nr1.clone();
+        let nr3 = &nr2;
+
+        assert_eq!(ref_to_usize(nr1), ref_to_usize(&nr2));
+        assert_eq!(ref_to_usize(nr1), ref_to_usize(nr3));
+    }
+
+    #[test]
+    fn edge() {
+        let node = RwNode::new(1, 1);
+        let boxed = Box::new(node);
+        let id = to_usize(boxed);
+
+        let e1 = Edge::ReadWrite(id);
+        let e2 = Edge::ReadWrite(id);
+        assert_eq!(e1, e2);
+
+        let e3 = Edge::WriteWrite(id);
+        assert!(e3 != e1);
+
+        let onode = RwNode::new(2, 1);
+        let oboxed = Box::new(onode);
+        let oid = to_usize(oboxed);
+
+        let e4 = Edge::ReadWrite(oid);
+        let e5 = Edge::WriteWrite(oid);
+
+        assert!(e1 != e4);
+        assert!(e1 != e5);
+        assert!(e4 != e5);
+    }
+
+    #[test]
+    fn node() {
+        let n1 = RwNode::new(1, 1);
+        let id1 = to_usize(Box::new(n1));
+        let node1 = from_usize(id1);
+
+        let n2 = RwNode::new(2, 1);
+        let id2 = to_usize(Box::new(n2));
+
+        node1.insert_incoming(Edge::ReadWrite(id2));
+        node1.insert_incoming(Edge::WriteWrite(id2));
+
+        assert_eq!(node1.is_incoming(), true);
+
+        node1.remove_incoming(&Edge::ReadWrite(id2));
+        assert_eq!(node1.is_incoming(), true);
+
+        let edge = Edge::WriteWrite(id2);
+        node1.remove_incoming(&edge);
+        assert_eq!(node1.is_incoming(), false);
+    }
+
+    #[test]
+    fn dfs() {
+        let n1 = RwNode::new(1, 1);
+        let id1 = to_usize(Box::new(n1));
+        let node1 = from_usize(id1);
+
+        let n2 = RwNode::new(2, 1);
+        let id2 = to_usize(Box::new(n2));
+        let node2 = from_usize(id2);
+
+        let n3 = RwNode::new(3, 1);
+        let id3 = to_usize(Box::new(n3));
+        let node3 = from_usize(id3);
+
+        node2.insert_incoming(Edge::WriteWrite(id1));
+
+        node3.insert_incoming(Edge::WriteWrite(id2));
+
+        node1.insert_incoming(Edge::WriteWrite(id3));
+
+        let mut res = FxHashSet::default();
+        res.insert(id1);
+        res.insert(id2);
+        res.insert(id3);
+
+        assert_eq!(node1.depth_first_search(true), res);
+    }
+}

--- a/src/workloads.rs
+++ b/src/workloads.rs
@@ -4,7 +4,7 @@ pub mod smallbank;
 
 pub mod acid;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
 pub enum IsolationLevel {
     ReadUncommitted,
     ReadCommitted,

--- a/src/workloads.rs
+++ b/src/workloads.rs
@@ -1,3 +1,12 @@
+use serde::{Deserialize, Serialize};
+
 pub mod smallbank;
 
 pub mod acid;
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum IsolationLevel {
+    ReadUncommitted,
+    ReadCommitted,
+    Serializable,
+}

--- a/src/workloads/acid/paramgen.rs
+++ b/src/workloads/acid/paramgen.rs
@@ -1,6 +1,7 @@
 use crate::common::message::{Message, Parameters, Transaction};
 use crate::common::parameter_generation::Generator;
 use crate::workloads::acid::{AcidTransaction, ACID_SF_MAP};
+use crate::workloads::IsolationLevel;
 
 use math::round;
 use rand::rngs::StdRng;
@@ -59,6 +60,7 @@ impl Generator for AcidGenerator {
             request_no,
             transaction: Transaction::Acid(transaction),
             parameters: Parameters::Acid(parameters),
+            isolation: IsolationLevel::Serializable,
         }
     }
 

--- a/src/workloads/smallbank/paramgen.rs
+++ b/src/workloads/smallbank/paramgen.rs
@@ -2,11 +2,12 @@ use crate::common::message::{Message, Parameters, Transaction};
 use crate::common::parameter_generation::Generator;
 use crate::workloads::smallbank::SmallBankTransaction;
 use crate::workloads::smallbank::*;
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use crate::workloads::IsolationLevel;
 
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+use std::fmt;
 
 /// SmallBank workload transaction generator.
 pub struct SmallBankGenerator {
@@ -75,10 +76,19 @@ impl Generator for SmallBankGenerator {
         let n: f32 = self.rng.gen();
         let (transaction, parameters) = self.get_params(n);
 
+        let m: f32 = self.rng.gen();
+
+        let isolation = match m {
+            x if x < 0.2 => IsolationLevel::ReadUncommitted,
+            x if x < 0.6 => IsolationLevel::ReadCommitted,
+            _ => IsolationLevel::Serializable,
+        };
+
         Message::Request {
             request_no: self.generated,
             transaction: Transaction::SmallBank(transaction),
             parameters: Parameters::SmallBank(parameters),
+            isolation,
         }
     }
 

--- a/src/workloads/smallbank/procedures.rs
+++ b/src/workloads/smallbank/procedures.rs
@@ -6,6 +6,7 @@ use crate::workloads::smallbank::error::SmallBankError;
 use crate::workloads::smallbank::paramgen::{
     Amalgamate, Balance, DepositChecking, SendPayment, TransactSaving, WriteCheck,
 };
+use crate::workloads::IsolationLevel;
 
 use crossbeam_epoch as epoch;
 use std::convert::TryFrom;
@@ -17,6 +18,7 @@ pub fn balance<'a>(
     params: Balance,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {
@@ -41,6 +43,7 @@ pub fn deposit_checking<'a>(
     params: DepositChecking,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {
@@ -66,6 +69,7 @@ pub fn transact_savings<'a>(
     params: TransactSaving,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {
@@ -95,6 +99,7 @@ pub fn amalgmate<'a>(
     params: Amalgamate,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {
@@ -127,6 +132,7 @@ pub fn write_check<'a>(
     params: WriteCheck,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {
@@ -168,6 +174,7 @@ pub fn send_payment<'a>(
     params: SendPayment,
     scheduler: &'a Scheduler,
     database: &'a Database,
+    isolation: IsolationLevel,
 ) -> Result<String, NonFatalError> {
     match &*database {
         Database::SmallBank(_) => {

--- a/src/workloads/smallbank/procedures.rs
+++ b/src/workloads/smallbank/procedures.rs
@@ -24,7 +24,7 @@ pub fn balance<'a>(
         Database::SmallBank(_) => {
             let offset = params.name as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin(); // register
+            let meta = scheduler.begin(isolation); // register
             scheduler.read_value(0, 0, offset, &meta, database, guard)?; // get customer id
             scheduler.read_value(1, 1, offset, &meta, database, guard)?; // get checking balance
             scheduler.read_value(2, 1, offset, &meta, database, guard)?; // get savings balance
@@ -49,7 +49,7 @@ pub fn deposit_checking<'a>(
         Database::SmallBank(_) => {
             let offset = params.name as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin();
+            let meta = scheduler.begin(isolation);
             scheduler.read_value(0, 0, offset, &meta, database, guard)?; // get customer id
             let res = scheduler.read_value(1, 1, offset, &meta, database, guard)?; // get current balance
             let balance = Data::from(f64::try_from(res)? + params.value); // new balance
@@ -75,7 +75,7 @@ pub fn transact_savings<'a>(
         Database::SmallBank(_) => {
             let offset = params.name as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin(); // register
+            let meta = scheduler.begin(isolation); // register
             scheduler.read_value(0, 0, offset, &meta, database, guard)?; // get customer id
             let res = scheduler.read_value(2, 1, offset, &meta, database, guard)?; // get savings balance
             let balance = f64::try_from(res)? + params.value; // new balance
@@ -106,7 +106,7 @@ pub fn amalgmate<'a>(
             let offset1 = params.name1 as usize;
             let offset2 = params.name2 as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin(); // register
+            let meta = scheduler.begin(isolation); // register
             scheduler.read_value(0, 0, offset1, &meta, database, guard)?; // read 1 -- get customer1 id
             let res1 = scheduler.read_value(2, 1, offset1, &meta, database, guard)?; // read 2 -- current savings balance (customer1)
             let res2 = scheduler.read_value(1, 1, offset1, &meta, database, guard)?; // read 3 -- current checking balance (customer1)
@@ -138,7 +138,7 @@ pub fn write_check<'a>(
         Database::SmallBank(_) => {
             let offset = params.name as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin();
+            let meta = scheduler.begin(isolation);
             scheduler.read_value(0, 0, offset, &meta, database, guard)?; // get customer id
             let savings =
                 f64::try_from(scheduler.read_value(2, 1, offset, &meta, database, guard)?)?; // get savings balance
@@ -181,7 +181,7 @@ pub fn send_payment<'a>(
             let offset1 = params.name1 as usize;
             let offset2 = params.name2 as usize;
             let guard = &epoch::pin(); // pin thread
-            let meta = scheduler.begin(); // register
+            let meta = scheduler.begin(isolation); // register
             scheduler.read_value(0, 0, offset1, &meta, database, guard)?; // get cust1 id
             let mut checking =
                 f64::try_from(scheduler.read_value(1, 1, offset1, &meta, database, guard)?)?; // get cust1 checking


### PR DESCRIPTION
Algorithm changes over SGT:
- [x] Conflict detection; only add relevant or obligatory edges 
- [ ] Cycle check; only traverse edges relevant to isolation level
- [ ] Commit rule; commit iff no incoming relevant edges
- [ ] Delete rule; delayed commit until there are no incoming edges

Benefits:
- No false negatives 
- Reduced latency; quicker commits and cycle checking 

Drawbacks:
- Higher graph maintenance costs; multiple edge sets 
- Useful if applications know what they are doing is safe

Evaluation 
- SGT vs MSGT; vary isolation level mix and contention level
- SGT vs MSGT; overhead when all at PL-3
- MSGT vs M2PL; higher thpt and lower abort rate


